### PR TITLE
Include a sublibrary, Qubesdb_ipv4, which builds an ipv4 from a Qubes.DB

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,4 @@
 S lib/*
-B _build
-PKG vchan.xen lwt mirage
+S lib/ipv4/*
+B _build/*
+PKG vchan.xen lwt mirage-types mirage-types-lwt tcpip ipaddr topkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - PACKAGE=mirage-qubes
+  - PACKAGE=mirage-qubes EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
   - OCAML_VERSION=4.02
   - OCAML_VERSION=4.03

--- a/_tags
+++ b/_tags
@@ -1,5 +1,7 @@
 true: annot, bin_annot, safe_string
 true: warn(A-4), strict_sequence
+<lib> : include
 <lib/*>: package(cstruct, logs, lwt, mirage-types.lwt, vchan.xen)
 <lib/*.cm{x,o}> and not <lib/qubes.cmx>: for-pack(Qubes)
+<lib/ipv4/*>: package(mirage-types.lwt, ipaddr, lwt, tcpip.ipv4)
 <lib/formats.*>: package(cstruct.ppx)

--- a/lib/ipv4/qubesdb_ipv4.ml
+++ b/lib/ipv4/qubesdb_ipv4.ml
@@ -1,0 +1,17 @@
+module Make(D: Qubes.S.DB) (Ethernet : V1_LWT.ETHIF) (Arp : V1_LWT.ARP) = struct
+  module IP = Static_ipv4.Make(Ethernet)(Arp)
+  include IP
+  let connect db ethif arp =
+    let (>>=?) ip f = match ip with
+      | None -> None
+      | Some s -> f s
+    in
+    let ip = D.read db "/qubes-ip" >>=? Ipaddr.V4.of_string in
+    let netmask = D.read db "/qubes-netmask" >>=? Ipaddr.V4.of_string in
+    let gateway = D.read db "/qubes-gateway" >>=? Ipaddr.V4.of_string in
+    match (ip, netmask) with
+    | Some ip , Some netmask ->
+      let network = Ipaddr.V4.Prefix.of_netmask netmask ip in
+      IP.connect ~ip ~network ~gateway ethif arp
+    | _ -> Lwt.fail_with "couldn't get ip configuration from qubesdb"
+end

--- a/lib/ipv4/qubesdb_ipv4.mli
+++ b/lib/ipv4/qubesdb_ipv4.mli
@@ -1,0 +1,10 @@
+module Make(D : Qubes.S.DB) (Ethernet : V1_LWT.ETHIF) (Arp : V1_LWT.ARP) : sig
+
+  include V1_LWT.IPV4 with type ethif = Ethernet.t
+  val connect : D.t -> Ethernet.t -> Arp.t -> t io
+  (** [connect db ethernet arp] attempts to use the provided [db] 
+   *  to look up the correct IPV4 information, and construct
+   *  an ipv4 implementation based on [ethernet] and [arp].  If [db]
+   *  can't be read or doesn't contain useful values, [connect] will
+   *  raise a failure. *)
+end

--- a/lib/ipv4/qubesdb_ipv4.mllib
+++ b/lib/ipv4/qubesdb_ipv4.mllib
@@ -1,0 +1,1 @@
+Qubesdb_ipv4

--- a/opam
+++ b/opam
@@ -6,7 +6,9 @@ homepage:     "https://github.com/talex5/mirage-qubes"
 bug-reports:  "https://github.com/talex5/mirage-qubes/issues"
 dev-repo:     "https://github.com/talex5/mirage-qubes.git"
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+        "--with-ipv4" "%{tcpip+ipaddr:installed}%"
+]
 
 depends: [
   "ocamlfind" {build}
@@ -20,5 +22,9 @@ depends: [
   "lwt"
   "mirage-types"
   "logs" { >= "0.5.0" }
+]
+depopts: [
+  "ipaddr"
+  "tcpip"
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/pkg/META
+++ b/pkg/META
@@ -6,3 +6,13 @@ archive(native) = "qubes.cmxa"
 plugin(byte) = "qubes.cma"
 plugin(native) = "qubes.cmxs"
 exists_if = "qubes.cma"
+
+package "ipv4" (
+  version = "%%VERSION_NUM%%"
+  description = "configure ipv4 automatically with qubesdb"
+  requires = "mirage-qubes mirage-types.lwt ipaddr lwt tcpip.ipv4"
+  archive(byte) = "qubesdb_ipv4.cma"
+  archive(native) = "qubesdb_ipv4.cmxa"
+  plugin(byte) = "qubesdb_ipv4.cma"
+  plugin(native) = "qubesdb_ipv4.cmxs"
+)

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -3,7 +3,14 @@
 #require "topkg"
 open Topkg
 
+let ipv4 = Conf.(key
+                 ~absent:false
+                 ~doc:"Build automatic IPv4 network configurators"
+                 "with-ipv4"
+                 Conf.bool
+)
 let () =
   Pkg.describe "mirage-qubes" @@ fun c ->
-          Ok [ Pkg.mllib ~api:["Qubes"] "lib/qubes.mllib";
+  Ok [ Pkg.mllib ~api:["Qubes"] "lib/qubes.mllib";
+       Pkg.mllib ~cond:(Conf.value c ipv4) "lib/ipv4/qubesdb_ipv4.mllib";
   ]


### PR DESCRIPTION
Qubesdb_ipv4 is intended for use with the `mirage` frontend tool as a
replacement for static or dynamic IPv4 configuration.  As QubesOS
doesn't provide a DHCP server for VMs and doesn't surface IP
configuration information before the VM exists, a nice interface for
statically configuring the interface with the information looked up from
QubesDB is required for MirageOS unikernels to be good network citizens
on QubesOS.

This module just wraps the `Static_ipv4` module from `tcpip` to build an `ipv4` with the supplied parameters from QubesDB.  It makes no attempt to monitor the database for changes or sync the unikernel's IP configuration with them.